### PR TITLE
Fix number of threads in nifi template

### DIFF
--- a/evalit/nifi/nifi-s3.xml
+++ b/evalit/nifi/nifi-s3.xml
@@ -211,7 +211,7 @@
             <config>
                 <bulletinLevel>WARN</bulletinLevel>
                 <comments></comments>
-                <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+                <concurrentlySchedulableTaskCount>10</concurrentlySchedulableTaskCount>
                 <descriptors>
                     <entry>
                         <key>Bucket</key>
@@ -556,7 +556,7 @@
             <config>
                 <bulletinLevel>WARN</bulletinLevel>
                 <comments></comments>
-                <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+                <concurrentlySchedulableTaskCount>10</concurrentlySchedulableTaskCount>
                 <descriptors>
                     <entry>
                         <key>Bucket</key>
@@ -865,7 +865,7 @@
             <config>
                 <bulletinLevel>WARN</bulletinLevel>
                 <comments></comments>
-                <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+                <concurrentlySchedulableTaskCount>10</concurrentlySchedulableTaskCount>
                 <descriptors>
                     <entry>
                         <key>Object Key</key>


### PR DESCRIPTION
Related to issue https://github.com/NASA-IMPACT/data-transfer-evaluation/issues/14

Actually only the number of concurrent tasks is fixed because the FlowFile that are queued by the FetchS3Object processor are just the path to the file that has been fetched and some other metadata. So that's not heavy at all.
See processor documentation (Write attributes part) : https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi/nifi-aws-nar/1.5.0/org.apache.nifi.processors.aws.s3.FetchS3Object/index.html