### PR TITLE
Parallelize log parsing mechanism for mft

### DIFF
--- a/evalit/nifi/nifi_automation.py
+++ b/evalit/nifi/nifi_automation.py
@@ -114,23 +114,27 @@ class NifiAutomation(AbstractAutomation):
         old_connections = process_groups_json["processGroupFlow"]["flow"]["connections"]
 
         for connection in old_connections:
-            print("Deleting connection " + connection["id"])
+            if self.debug:
+                print("Deleting connection " + connection["id"])
             r = requests.delete(
                 nifi_url + "/connections/" + connection["id"],
                 params={"version": str(connection["revision"]["version"])},
                 verify=False,
             )
-            print("Status", r.status_code)
+            if self.debug:
+                print("Status", r.status_code)
 
         old_processors = process_groups_json["processGroupFlow"]["flow"]["processors"]
         for processor in old_processors:
-            print("Deleting processor ", processor["id"])
+            if self.debug:
+                print("Deleting processor ", processor["id"])
             r = requests.delete(
                 nifi_url + "/processors/" + processor["id"],
                 params={"version": str(processor["revision"]["version"])},
                 verify=False,
             )
-            print("Status", r.status_code)
+            if self.debug:
+                print("Status", r.status_code)
 
         # Deletes all template files
 
@@ -138,7 +142,10 @@ class NifiAutomation(AbstractAutomation):
         templates = r.json()["templates"]
 
         for template in templates:
-            print("Deleting template ", template["id"], template["template"]["name"])
+            if self.debug:
+                print(
+                    "Deleting template ", template["id"], template["template"]["name"]
+                )
             requests.delete(nifi_url + "/templates/" + template["id"], verify=False)
 
             # Upload the template file
@@ -209,13 +216,15 @@ class NifiAutomation(AbstractAutomation):
             "disconnectedNodeAcknowledged": "false",
         }
 
-        print("Updating ListS3 processor")
+        if self.debug:
+            print("Updating ListS3 processor")
         r = requests.put(
             nifi_url + "/processors/" + list_s3_processor["id"],
             json=list_s3_update_json,
             verify=False,
         )
-        print("Status", r.status_code)
+        if self.debug:
+            print("Status", r.status_code)
 
         fetch_s3_processor = processor_name_map["FetchS3Object"]
         fetch_s3_update_json = {

--- a/tests/controller_test2.py
+++ b/tests/controller_test2.py
@@ -50,6 +50,7 @@ controller = (
             nifi_dir=nifi_installation,
             files=filenames,
             xml_conf=os.getenv("NIFI_XML_CONF"),
+            debug=False,
         )
     )
     .add_automation(
@@ -65,5 +66,6 @@ results = controller.run(
     nifi_log_poll_time=5,
     mft_log_poll_time=5,
     mft_njobs=multiprocessing.cpu_count(),
+    mft_log_parser_njobs=1,
 )
-logger.debug(results)
+logger.info(results)


### PR DESCRIPTION
# Major Changes
- The parallelization parameter is controlled by `mft_log_parser_njobs` in
the kwargs. This parameter is passed to controller's `run(...)`.

# Minor changes
- Use `mft_log_poll_time` as a wait time (in seconds) to poll the mft logs.
- Use `MFTAutomation._LOG_START_PHRASE = "STARTING"` and `MFTAutomation._LOG_COMPLETE_PHRASE = "COMPLETED"` phrases to parse logs for mft transfers.

